### PR TITLE
Add config for max sidebar sizes

### DIFF
--- a/src/manager/manager.html
+++ b/src/manager/manager.html
@@ -47,9 +47,9 @@
 						</div>
 						<p class="empty-tag-search" id="empty-tag-search">No tags selected.</p>
 						<div class="tag-search-container" id="tag-search-container"></div>
-						<div class="resizer enforceMin"></div>
+						<div class="resizer enforceMin" id="searchResizer"></div>
 					</div>
-					<div class="main-center">
+					<div class="main-center" style="min-width: 30rem">
 						<div class="button-bar">
 							<div class="open-extracted-folder" id="open-extracted-folder" title="Open extracted game folder" style="display: none">
 								<img src="./assets/foldergame.png" />
@@ -102,7 +102,7 @@
 						</div>
 					</div>
 					<div class="main-rightbar" style="width: 22rem">
-						<div class="resizer left enforceMin"></div>
+						<div class="resizer left enforceMin" id="modinfoResizer"></div>
 						<div class="rightbar-top">
 							<p class="title" id="mod-info-title">Mod Name</p>
 						</div>

--- a/src/manager/manager.js
+++ b/src/manager/manager.js
@@ -79,9 +79,23 @@ function handleResizer(resizer) {
 	});
 
 	if (resizer.classList.contains("enforceMin")) {
-		resizer.parentElement.style.minWidth = config.manager.minResizerSize || 0;
+		resizer.parentElement.style.minWidth = config.manager.minResizerSize !== 0 ? config.manager.minResizerSize : undefined;
 		events.on("config-changed", (newConfig) => {
-			parent.style.minWidth = newConfig.manager.minResizerSize || 0;
+			parent.style.minWidth = newConfig.manager.minResizerSize !== 0 ? newConfig.manager.minResizerSize : undefined;
+		});
+	}
+
+	if (resizer.id === "modinfoResizer") {
+		resizer.parentElement.style.maxWidth = config.manager.maxModInfoSidebarSize !== 0 ? config.manager.maxModInfoSidebarSize : undefined;
+		events.on("config-changed", (newConfig) => {
+			parent.style.maxWidth = newConfig.manager.maxModInfoSidebarSize !== 0 ? newConfig.manager.maxModInfoSidebarSize : undefined;
+		});
+	}
+
+	if (resizer.id === "searchResizer") {
+		resizer.parentElement.style.maxWidth = config.manager.maxSearchSidebarSize || 0;
+		events.on("config-changed", (newConfig) => {
+			parent.style.maxWidth = newConfig.manager.maxSearchSidebarSize || 0;
 		});
 	}
 
@@ -239,7 +253,7 @@ class ConfigSchemaElement {
 
 				// Create the input element based on the schema type
 				let value = configSection?.[key] ?? schemaValue.default;
-				if (!value) value = "";
+				if (value === undefined) value = "";
 				let input;
 				let extraInputs = [];
 				switch (schemaValue.type) {

--- a/src/schema.fluxloader-config.json
+++ b/src/schema.fluxloader-config.json
@@ -122,6 +122,18 @@
 			"default": 200,
 			"min": 0
 		},
+		"maxSearchSidebarSize": {
+			"type": "number",
+			"description": "The maximum size, in pixels, the left search sidebar can expand to",
+			"default": 350,
+			"min": 0
+		},
+		"maxModInfoSidebarSize": {
+			"type": "number",
+			"description": "The maximum size, in pixels, the right modinfo sidebar can expand to",
+			"default": 800,
+			"min": 0
+		},
 		"updateOS": {
 			"type": "dropdown",
 			"description": "Which file to download when downloading updates",


### PR DESCRIPTION
Allows the user to set a maximum size for the sidebars independently. Fixes issue #28. Also minor config render fix, and gave the main mod list a min width. If the user sets the max width to `0`, it will be treated as infinite and remove the limit.